### PR TITLE
Fix list functionality

### DIFF
--- a/lib/imap-filter/functionality.rb
+++ b/lib/imap-filter/functionality.rb
@@ -112,7 +112,7 @@ module ImapFilter
 
       def list *a, **h
         subject_list.each do |subject|
-          puts subject.attr[subj].to_s.strip.tr("\n\r", '').light_yellow
+          puts subject.light_yellow
         end unless seq.empty?
       end
 


### PR DESCRIPTION
subject_list already maps the fetched entries to a list of strings. Consequently, accessing .attr again when iterating over these strings in the method list fails.